### PR TITLE
use find_packages to include subpackages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='ultrafastFitFunctions',
     version='0.5.0',
-    packages=['ultrafastFitFunctions'],
+    packages=find_packages(),
     url='https://github.com/EmCeBeh/ultrafastFitFunctions',  # Optional
     install_requires=['numpy', 'scipy', 'uncertainties'],  # Optional
     license='',


### PR DESCRIPTION
Hello,

I've just noticed that the previous fixes were not enough for proper installation. The previous version worked if the user was located in the package folder. I did not test it from elsewhere. Now the `setup.py` will locate all packages (also in sub-folder `peak`) and package them properly.